### PR TITLE
Rework PhoenixOdometryThread

### DIFF
--- a/src/main/java/frc/robot/subsystems/swerve/GyroIOPigeon2.java
+++ b/src/main/java/frc/robot/subsystems/swerve/GyroIOPigeon2.java
@@ -49,7 +49,7 @@ public class GyroIOPigeon2 implements GyroIO {
 
     var samples =
         PhoenixOdometryThread.getInstance().samplesSince(lastUpdate, ImmutableSet.of(yaw));
-    if (! samples.isEmpty()) {
+    if (!samples.isEmpty()) {
       lastUpdate = samples.get(samples.size() - 1).timestamp();
     }
 

--- a/src/main/java/frc/robot/subsystems/swerve/GyroIOPigeon2.java
+++ b/src/main/java/frc/robot/subsystems/swerve/GyroIOPigeon2.java
@@ -55,6 +55,7 @@ public class GyroIOPigeon2 implements GyroIO {
 
     inputs.odometryYawPositions =
         samples.stream()
+            .filter(s -> s != null)
             .map(s -> Rotation2d.fromDegrees(s.values().get(yaw)))
             .toArray(Rotation2d[]::new);
   }

--- a/src/main/java/frc/robot/subsystems/swerve/GyroIOPigeon2.java
+++ b/src/main/java/frc/robot/subsystems/swerve/GyroIOPigeon2.java
@@ -18,16 +18,17 @@ import com.ctre.phoenix6.StatusCode;
 import com.ctre.phoenix6.StatusSignal;
 import com.ctre.phoenix6.configs.Pigeon2Configuration;
 import com.ctre.phoenix6.hardware.Pigeon2;
+import com.google.common.collect.Sets;
 import edu.wpi.first.math.geometry.Rotation2d;
 import edu.wpi.first.math.util.Units;
-import java.util.Queue;
+import frc.robot.subsystems.swerve.PhoenixOdometryThread.Registration;
 
 /** IO implementation for Pigeon2 */
 public class GyroIOPigeon2 implements GyroIO {
   private final Pigeon2 pigeon = new Pigeon2(SwerveSubsystem.PIGEON_ID);
   private final StatusSignal<Double> yaw = pigeon.getYaw();
-  private final Queue<Double> yawPositionQueue;
   private final StatusSignal<Double> yawVelocity = pigeon.getAngularVelocityZWorld();
+  private double lastUpdate = 0;
 
   public GyroIOPigeon2() {
     var config = new Pigeon2Configuration();
@@ -36,7 +37,8 @@ public class GyroIOPigeon2 implements GyroIO {
     yaw.setUpdateFrequency(Module.ODOMETRY_FREQUENCY_HZ);
     yawVelocity.setUpdateFrequency(100.0);
     pigeon.optimizeBusUtilization();
-    yawPositionQueue = PhoenixOdometryThread.getInstance().registerSignal(pigeon, pigeon.getYaw());
+    PhoenixOdometryThread.getInstance()
+        .registerSignals(new Registration(pigeon, Sets.newHashSet(yaw)));
   }
 
   @Override
@@ -45,11 +47,14 @@ public class GyroIOPigeon2 implements GyroIO {
     inputs.yawPosition = Rotation2d.fromDegrees(yaw.getValueAsDouble());
     inputs.yawVelocityRadPerSec = Units.degreesToRadians(yawVelocity.getValueAsDouble());
 
+    var samples =
+        PhoenixOdometryThread.getInstance().samplesSince(lastUpdate, Sets.newHashSet(yaw));
+    lastUpdate = samples.get(samples.size() - 1).timestamp();
+
     inputs.odometryYawPositions =
-        yawPositionQueue.stream()
-            .map((Double value) -> Rotation2d.fromDegrees(value))
+        samples.stream()
+            .map(s -> Rotation2d.fromDegrees(s.values().get(yaw)))
             .toArray(Rotation2d[]::new);
-    yawPositionQueue.clear();
   }
 
   @Override

--- a/src/main/java/frc/robot/subsystems/swerve/GyroIOPigeon2.java
+++ b/src/main/java/frc/robot/subsystems/swerve/GyroIOPigeon2.java
@@ -49,7 +49,9 @@ public class GyroIOPigeon2 implements GyroIO {
 
     var samples =
         PhoenixOdometryThread.getInstance().samplesSince(lastUpdate, ImmutableSet.of(yaw));
-    lastUpdate = samples.get(samples.size() - 1).timestamp();
+    if (! samples.isEmpty()) {
+      lastUpdate = samples.get(samples.size() - 1).timestamp();
+    }
 
     inputs.odometryYawPositions =
         samples.stream()

--- a/src/main/java/frc/robot/subsystems/swerve/GyroIOPigeon2.java
+++ b/src/main/java/frc/robot/subsystems/swerve/GyroIOPigeon2.java
@@ -55,9 +55,10 @@ public class GyroIOPigeon2 implements GyroIO {
 
     inputs.odometryYawPositions =
         samples.stream()
-            .filter(s -> s != null)
-            .map(s -> Rotation2d.fromDegrees(s.values().get(yaw)))
-            .toArray(Rotation2d[]::new);
+          .map(s -> s.values().get(yaw))
+          .filter(s -> s != null)
+          .map(Rotation2d::fromRotations)
+          .toArray(Rotation2d[]::new);
   }
 
   @Override

--- a/src/main/java/frc/robot/subsystems/swerve/GyroIOPigeon2.java
+++ b/src/main/java/frc/robot/subsystems/swerve/GyroIOPigeon2.java
@@ -18,7 +18,7 @@ import com.ctre.phoenix6.StatusCode;
 import com.ctre.phoenix6.StatusSignal;
 import com.ctre.phoenix6.configs.Pigeon2Configuration;
 import com.ctre.phoenix6.hardware.Pigeon2;
-import com.google.common.collect.Sets;
+import com.google.common.collect.ImmutableSet;
 import edu.wpi.first.math.geometry.Rotation2d;
 import edu.wpi.first.math.util.Units;
 import frc.robot.subsystems.swerve.PhoenixOdometryThread.Registration;
@@ -38,7 +38,7 @@ public class GyroIOPigeon2 implements GyroIO {
     yawVelocity.setUpdateFrequency(100.0);
     pigeon.optimizeBusUtilization();
     PhoenixOdometryThread.getInstance()
-        .registerSignals(new Registration(pigeon, Sets.newHashSet(yaw)));
+        .registerSignals(new Registration(pigeon, ImmutableSet.of(yaw)));
   }
 
   @Override
@@ -48,7 +48,7 @@ public class GyroIOPigeon2 implements GyroIO {
     inputs.yawVelocityRadPerSec = Units.degreesToRadians(yawVelocity.getValueAsDouble());
 
     var samples =
-        PhoenixOdometryThread.getInstance().samplesSince(lastUpdate, Sets.newHashSet(yaw));
+        PhoenixOdometryThread.getInstance().samplesSince(lastUpdate, ImmutableSet.of(yaw));
     lastUpdate = samples.get(samples.size() - 1).timestamp();
 
     inputs.odometryYawPositions =

--- a/src/main/java/frc/robot/subsystems/swerve/ModuleIOReal.java
+++ b/src/main/java/frc/robot/subsystems/swerve/ModuleIOReal.java
@@ -25,7 +25,7 @@ import com.ctre.phoenix6.hardware.TalonFX;
 import com.ctre.phoenix6.signals.FeedbackSensorSourceValue;
 import com.ctre.phoenix6.signals.InvertedValue;
 import com.ctre.phoenix6.signals.NeutralModeValue;
-import com.google.common.collect.Sets;
+import com.google.common.collect.ImmutableSet;
 import edu.wpi.first.math.geometry.Rotation2d;
 import edu.wpi.first.math.util.Units;
 import frc.robot.subsystems.swerve.Module.ModuleConstants;
@@ -157,8 +157,8 @@ public class ModuleIOReal implements ModuleIO {
 
     PhoenixOdometryThread.getInstance()
         .registerSignals(
-            new Registration(driveTalon, Sets.newHashSet(driveTalon.getPosition())),
-            new Registration(turnTalon, Sets.newHashSet(turnPosition)));
+            new Registration(driveTalon, ImmutableSet.of(drivePosition)),
+            new Registration(turnTalon, ImmutableSet.of(turnPosition)));
 
     BaseStatusSignal.setUpdateFrequencyForAll(
         Module.ODOMETRY_FREQUENCY_HZ, drivePosition, turnPosition);
@@ -202,7 +202,7 @@ public class ModuleIOReal implements ModuleIO {
 
     var samples =
         PhoenixOdometryThread.getInstance()
-            .samplesSince(lastUpdate, Sets.newHashSet(drivePosition, turnPosition));
+            .samplesSince(lastUpdate, ImmutableSet.of(drivePosition, turnPosition));
     lastUpdate = samples.get(samples.size() - 1).timestamp();
 
     inputs.odometryTimestamps = samples.stream().mapToDouble(s -> s.timestamp()).toArray();

--- a/src/main/java/frc/robot/subsystems/swerve/ModuleIOReal.java
+++ b/src/main/java/frc/robot/subsystems/swerve/ModuleIOReal.java
@@ -213,8 +213,9 @@ public class ModuleIOReal implements ModuleIO {
     inputs.odometryTurnPositions =
         samples.stream()
             // should be after offset + gear ratio
+            .map(s -> s.values().get(turnPosition))
             .filter(s -> s != null)
-            .map(s -> Rotation2d.fromRotations(s.values().get(turnPosition)))
+            .map(Rotation2d::fromRotations)
             .toArray(Rotation2d[]::new);
   }
 

--- a/src/main/java/frc/robot/subsystems/swerve/ModuleIOReal.java
+++ b/src/main/java/frc/robot/subsystems/swerve/ModuleIOReal.java
@@ -203,7 +203,10 @@ public class ModuleIOReal implements ModuleIO {
     var samples =
         PhoenixOdometryThread.getInstance()
             .samplesSince(lastUpdate, ImmutableSet.of(drivePosition, turnPosition));
-    lastUpdate = samples.get(samples.size() - 1).timestamp();
+    if (! samples.isEmpty()) {
+      lastUpdate = samples.get(samples.size() - 1).timestamp();
+
+    }
 
     inputs.odometryTimestamps = samples.stream().mapToDouble(s -> s.timestamp()).toArray();
     inputs.odometryDrivePositionsMeters =

--- a/src/main/java/frc/robot/subsystems/swerve/ModuleIOReal.java
+++ b/src/main/java/frc/robot/subsystems/swerve/ModuleIOReal.java
@@ -203,9 +203,8 @@ public class ModuleIOReal implements ModuleIO {
     var samples =
         PhoenixOdometryThread.getInstance()
             .samplesSince(lastUpdate, ImmutableSet.of(drivePosition, turnPosition));
-    if (! samples.isEmpty()) {
+    if (!samples.isEmpty()) {
       lastUpdate = samples.get(samples.size() - 1).timestamp();
-
     }
 
     inputs.odometryTimestamps = samples.stream().mapToDouble(s -> s.timestamp()).toArray();

--- a/src/main/java/frc/robot/subsystems/swerve/ModuleIOReal.java
+++ b/src/main/java/frc/robot/subsystems/swerve/ModuleIOReal.java
@@ -209,10 +209,11 @@ public class ModuleIOReal implements ModuleIO {
 
     inputs.odometryTimestamps = samples.stream().mapToDouble(s -> s.timestamp()).toArray();
     inputs.odometryDrivePositionsMeters =
-        samples.stream().mapToDouble(s -> s.values().get(drivePosition)).toArray();
+        samples.stream().filter(s -> s != null).mapToDouble(s -> s.values().get(drivePosition)).toArray();
     inputs.odometryTurnPositions =
         samples.stream()
             // should be after offset + gear ratio
+            .filter(s -> s != null)
             .map(s -> Rotation2d.fromRotations(s.values().get(turnPosition)))
             .toArray(Rotation2d[]::new);
   }

--- a/src/main/java/frc/robot/subsystems/swerve/PhoenixOdometryThread.java
+++ b/src/main/java/frc/robot/subsystems/swerve/PhoenixOdometryThread.java
@@ -102,17 +102,17 @@ public class PhoenixOdometryThread extends Thread {
       readLock.lock();
 
       return journal.stream()
-      .filter(s -> s.timestamp > timestamp)
-      .map(
-          s -> {
-            var filteredValues =
-                s.values.entrySet().stream()
-                    .filter(e -> signals.contains(e.getKey()))
-                    .collect(
-                        Collectors.toUnmodifiableMap(Map.Entry::getKey, Map.Entry::getValue));
-            return new Samples(s.timestamp, filteredValues);
-          })
-      .collect(Collectors.toUnmodifiableList());
+          .filter(s -> s.timestamp > timestamp)
+          .map(
+              s -> {
+                var filteredValues =
+                    s.values.entrySet().stream()
+                        .filter(e -> signals.contains(e.getKey()))
+                        .collect(
+                            Collectors.toUnmodifiableMap(Map.Entry::getKey, Map.Entry::getValue));
+                return new Samples(s.timestamp, filteredValues);
+              })
+          .collect(Collectors.toUnmodifiableList());
     } finally {
       readLock.unlock();
     }
@@ -125,7 +125,7 @@ public class PhoenixOdometryThread extends Thread {
       var writeLock = journalLock.writeLock();
 
       try {
-          writeLock.lock();
+        writeLock.lock();
 
         // NOTE (kevinclark): The toArray here in a tight loop is kind of ugly
         // but keeping up a symmetric array is too and it's probably negligible on latency.

--- a/src/main/java/frc/robot/subsystems/swerve/PhoenixOdometryThread.java
+++ b/src/main/java/frc/robot/subsystems/swerve/PhoenixOdometryThread.java
@@ -11,6 +11,8 @@
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU General Public License for more details.
 
+// Copyright 2024 FRC 8033 and Kevin Clark
+
 package frc.robot.subsystems.swerve;
 
 import com.ctre.phoenix6.BaseStatusSignal;

--- a/src/main/java/frc/robot/subsystems/swerve/PhoenixOdometryThread.java
+++ b/src/main/java/frc/robot/subsystems/swerve/PhoenixOdometryThread.java
@@ -140,16 +140,14 @@ public class PhoenixOdometryThread extends Thread {
   }
 
   private double timestampFor(Set<BaseStatusSignal> signals) {
-    double timestamp = Logger.getRealTimestamp() / 1e6;
-
-    final double totalLatency =
-        signals.stream().mapToDouble(s -> s.getTimestamp().getLatency()).sum();
+    final double totalTimestamp =
+        signals.stream().mapToDouble(s -> s.getTimestamp().getTime()).sum();
 
     // Account for mean latency for a "good enough" timestamp
     if (!signals.isEmpty()) {
-      timestamp -= totalLatency / signals.size();
+      return totalTimestamp / signals.size();
+    } else {
+      return Logger.getRealTimestamp() / 1e6;
     }
-
-    return timestamp;
   }
 }

--- a/src/test/java/frc/robot/subsystems/swerve/PhoenixOdometryThreadTest.java
+++ b/src/test/java/frc/robot/subsystems/swerve/PhoenixOdometryThreadTest.java
@@ -31,6 +31,15 @@ public class PhoenixOdometryThreadTest {
   }
 
   @Test
+  void statusSignalsFromDifferentDevicesShouldNotBeEqual() {
+    TalonFX otherTalon = new TalonFX(1);
+    Assertions.assertNotEquals(talon.getAcceleration(), otherTalon.getAcceleration());
+
+    Assertions.assertNotEquals(
+        talon.getAcceleration().hashCode(), otherTalon.getAcceleration().hashCode());
+  }
+
+  @Test
   void samplesSinceReturnsNothingWhenNoSamples() {
     var thread = PhoenixOdometryThread.createWithJournal(Queues.newArrayDeque());
     var samples = thread.samplesSince(0, ImmutableSet.of(talon.getAcceleration()));

--- a/src/test/java/frc/robot/subsystems/swerve/PhoenixOdometryThreadTest.java
+++ b/src/test/java/frc/robot/subsystems/swerve/PhoenixOdometryThreadTest.java
@@ -4,8 +4,8 @@ import com.ctre.phoenix6.BaseStatusSignal;
 import com.ctre.phoenix6.hardware.TalonFX;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Queues;
-import com.google.common.collect.Sets;
 import frc.robot.subsystems.swerve.PhoenixOdometryThread.Samples;
 import java.util.Collections;
 import java.util.Map;
@@ -33,7 +33,7 @@ public class PhoenixOdometryThreadTest {
   @Test
   void samplesSinceReturnsNothingWhenNoSamples() {
     var thread = PhoenixOdometryThread.createWithJournal(Queues.newArrayDeque());
-    var samples = thread.samplesSince(0, Sets.newHashSet(talon.getAcceleration()));
+    var samples = thread.samplesSince(0, ImmutableSet.of(talon.getAcceleration()));
     Assertions.assertEquals(Collections.emptyList(), samples);
   }
 
@@ -43,7 +43,7 @@ public class PhoenixOdometryThreadTest {
     var sample = new Samples(10, sampleValue);
     var thread =
         PhoenixOdometryThread.createWithJournal(Queues.newArrayDeque(ImmutableList.of(sample)));
-    var samples = thread.samplesSince(0, Sets.newHashSet(talon.getAcceleration()));
+    var samples = thread.samplesSince(0, ImmutableSet.of(talon.getAcceleration()));
     Assertions.assertEquals(ImmutableList.of(sample), samples);
   }
 
@@ -53,7 +53,7 @@ public class PhoenixOdometryThreadTest {
     var sample = new Samples(10, sampleValue);
     var thread =
         PhoenixOdometryThread.createWithJournal(Queues.newArrayDeque(ImmutableList.of(sample)));
-    var samples = thread.samplesSince(15, Sets.newHashSet(talon.getAcceleration()));
+    var samples = thread.samplesSince(15, ImmutableSet.of(talon.getAcceleration()));
     Assertions.assertEquals(Collections.emptyList(), samples);
   }
 
@@ -63,7 +63,20 @@ public class PhoenixOdometryThreadTest {
     var sample = new Samples(10, sampleValue);
     var thread =
         PhoenixOdometryThread.createWithJournal(Queues.newArrayDeque(ImmutableList.of(sample)));
-    var samples = thread.samplesSince(10, Sets.newHashSet(talon.getAcceleration()));
+    var samples = thread.samplesSince(10, ImmutableSet.of(talon.getAcceleration()));
     Assertions.assertEquals(Collections.emptyList(), samples);
+  }
+
+  @Test
+  void samplesSinceOnlySelectsRequestedSignals() {
+    Map<BaseStatusSignal, Double> sampleValue =
+        ImmutableMap.of(talon.getAcceleration(), 42.0, talon.getPosition(), 1024.0);
+    var sample = new Samples(10, sampleValue);
+    var thread =
+        PhoenixOdometryThread.createWithJournal(Queues.newArrayDeque(ImmutableList.of(sample)));
+    var samples = thread.samplesSince(0, ImmutableSet.of(talon.getAcceleration()));
+
+    var filteredSample = new Samples(10, ImmutableMap.of(talon.getAcceleration(), 42.0));
+    Assertions.assertEquals(ImmutableList.of(filteredSample), samples);
   }
 }

--- a/src/test/java/frc/robot/subsystems/swerve/PhoenixOdometryThreadTest.java
+++ b/src/test/java/frc/robot/subsystems/swerve/PhoenixOdometryThreadTest.java
@@ -1,0 +1,69 @@
+package frc.robot.subsystems.swerve;
+
+import com.ctre.phoenix6.BaseStatusSignal;
+import com.ctre.phoenix6.hardware.TalonFX;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Queues;
+import com.google.common.collect.Sets;
+import frc.robot.subsystems.swerve.PhoenixOdometryThread.Samples;
+import java.util.Collections;
+import java.util.Map;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class PhoenixOdometryThreadTest {
+  private TalonFX talon;
+
+  @BeforeEach
+  void setup() {
+    talon = new TalonFX(0);
+  }
+
+  @Test
+  void statusSignalsShouldBeEqualIfRequestedTwice() {
+    // This is to ensure that phoenix's StatusSignals are actually usable as hash keys
+    Assertions.assertEquals(talon.getAcceleration(), talon.getAcceleration());
+    Assertions.assertNotEquals(talon.getAcceleration(), talon.getPosition());
+
+    Assertions.assertEquals(talon.getAcceleration().hashCode(), talon.getAcceleration().hashCode());
+  }
+
+  @Test
+  void samplesSinceReturnsNothingWhenNoSamples() {
+    var thread = PhoenixOdometryThread.createWithJournal(Queues.newArrayDeque());
+    var samples = thread.samplesSince(0, Sets.newHashSet(talon.getAcceleration()));
+    Assertions.assertEquals(Collections.emptyList(), samples);
+  }
+
+  @Test
+  void samplesSinceReturnsAfterTimestamp() {
+    Map<BaseStatusSignal, Double> sampleValue = ImmutableMap.of(talon.getAcceleration(), 42.0);
+    var sample = new Samples(10, sampleValue);
+    var thread =
+        PhoenixOdometryThread.createWithJournal(Queues.newArrayDeque(ImmutableList.of(sample)));
+    var samples = thread.samplesSince(0, Sets.newHashSet(talon.getAcceleration()));
+    Assertions.assertEquals(ImmutableList.of(sample), samples);
+  }
+
+  @Test
+  void samplesSinceIgnoresBeforeTimestamp() {
+    Map<BaseStatusSignal, Double> sampleValue = ImmutableMap.of(talon.getAcceleration(), 42.0);
+    var sample = new Samples(10, sampleValue);
+    var thread =
+        PhoenixOdometryThread.createWithJournal(Queues.newArrayDeque(ImmutableList.of(sample)));
+    var samples = thread.samplesSince(15, Sets.newHashSet(talon.getAcceleration()));
+    Assertions.assertEquals(Collections.emptyList(), samples);
+  }
+
+  @Test
+  void samplesSinceIgnoresWhenTimestampEqual() {
+    Map<BaseStatusSignal, Double> sampleValue = ImmutableMap.of(talon.getAcceleration(), 42.0);
+    var sample = new Samples(10, sampleValue);
+    var thread =
+        PhoenixOdometryThread.createWithJournal(Queues.newArrayDeque(ImmutableList.of(sample)));
+    var samples = thread.samplesSince(10, Sets.newHashSet(talon.getAcceleration()));
+    Assertions.assertEquals(Collections.emptyList(), samples);
+  }
+}


### PR DESCRIPTION
This pulls all the thread-sensitive stuff inside PhoenixOdometryThread, makes it so we only pull each status signal once, and ensures that timestamps are 1:1 associated with a sampling.