### PR TITLE
fix centering motor not logging properly

### DIFF
--- a/src/main/java/frc/robot/subsystems/intake/IntakeIOReal.java
+++ b/src/main/java/frc/robot/subsystems/intake/IntakeIOReal.java
@@ -55,7 +55,15 @@ public class IntakeIOReal implements IntakeIO {
   /** Updates the set of loggable inputs. */
   @Override
   public void updateInputs(IntakeIOInputs inputs) {
-    BaseStatusSignal.refreshAll(intakeVelocity, intakeVoltage, intakeAmperage, intakeTemp);
+    BaseStatusSignal.refreshAll(
+        intakeVelocity,
+        intakeVoltage,
+        intakeAmperage,
+        intakeTemp,
+        centeringVelocity,
+        centeringVoltage,
+        centeringAmperage,
+        centeringTemp);
     inputs.intakeVelocityRotationsPerSecond = intakeVelocity.getValueAsDouble();
     inputs.intakeAppliedVolts = intakeVoltage.getValueAsDouble();
     inputs.intakeCurrentAmps = intakeAmperage.getValueAsDouble();


### PR DESCRIPTION
i forgot to add it to the call to `BaseStatusSignal.refreshAll`