### PR TITLE
Handle null modules

### DIFF
--- a/src/main/java/frc/robot/subsystems/swerve/Module.java
+++ b/src/main/java/frc/robot/subsystems/swerve/Module.java
@@ -19,6 +19,7 @@ import edu.wpi.first.math.kinematics.SwerveModulePosition;
 import edu.wpi.first.math.kinematics.SwerveModuleState;
 import edu.wpi.first.math.util.Units;
 import frc.robot.subsystems.swerve.PhoenixOdometryThread.Samples;
+import frc.robot.utils.NullableDouble;
 import frc.robot.utils.NullableRotation2d;
 import java.util.List;
 import org.littletonrobotics.junction.Logger;
@@ -71,12 +72,12 @@ public class Module {
     int sampleCount = inputs.odometryTimestamps.length; // All signals are sampled together
     odometryPositions = new SwerveModulePosition[sampleCount];
     for (int i = 0; i < sampleCount; i++) {
-      double positionMeters = inputs.odometryDrivePositionsMeters[i];
+      NullableDouble positionMeters = inputs.odometryDrivePositionsMeters[i];
       NullableRotation2d angle = inputs.odometryTurnPositions[i];
-      if (angle.get() == null) {
+      if (angle.get() == null || positionMeters.get() == null) {
         odometryPositions[i] = null; // SwerveSubsystem deals with this
       } else {
-        odometryPositions[i] = new SwerveModulePosition(positionMeters, angle.get());
+        odometryPositions[i] = new SwerveModulePosition(positionMeters.get(), angle.get());
       }
     }
   }

--- a/src/main/java/frc/robot/subsystems/swerve/ModuleIO.java
+++ b/src/main/java/frc/robot/subsystems/swerve/ModuleIO.java
@@ -15,6 +15,7 @@ package frc.robot.subsystems.swerve;
 
 import edu.wpi.first.math.geometry.Rotation2d;
 import frc.robot.subsystems.swerve.PhoenixOdometryThread.Samples;
+import frc.robot.utils.NullableDouble;
 import frc.robot.utils.NullableRotation2d;
 import java.util.List;
 import org.littletonrobotics.junction.AutoLog;
@@ -33,7 +34,7 @@ public interface ModuleIO {
     public double turnAppliedVolts = 0.0;
     public double[] turnCurrentAmps = new double[] {};
 
-    public double[] odometryDrivePositionsMeters = new double[] {};
+    public NullableDouble[] odometryDrivePositionsMeters = new NullableDouble[] {};
     public NullableRotation2d[] odometryTurnPositions = new NullableRotation2d[] {};
     public double[] odometryTimestamps = new double[] {};
   }

--- a/src/main/java/frc/robot/subsystems/swerve/ModuleIOReal.java
+++ b/src/main/java/frc/robot/subsystems/swerve/ModuleIOReal.java
@@ -33,6 +33,7 @@ import edu.wpi.first.math.util.Units;
 import frc.robot.subsystems.swerve.Module.ModuleConstants;
 import frc.robot.subsystems.swerve.PhoenixOdometryThread.Registration;
 import frc.robot.subsystems.swerve.PhoenixOdometryThread.Samples;
+import frc.robot.utils.NullableDouble;
 import frc.robot.utils.NullableRotation2d;
 import java.util.List;
 
@@ -216,7 +217,11 @@ public class ModuleIOReal implements ModuleIO {
     inputs.odometryTimestamps =
         asyncOdometrySamples.stream().mapToDouble(s -> s.timestamp()).toArray();
     inputs.odometryDrivePositionsMeters =
-        asyncOdometrySamples.stream().mapToDouble(s -> s.values().get(drivePosition)).toArray();
+        asyncOdometrySamples.stream()
+            .map(s -> s.values().get(drivePosition))
+            .map(d -> d == null ? new NullableDouble(null) : new NullableDouble(d))
+            .toArray(NullableDouble[]::new);
+    // mapToDouble(s -> s.values().get(drivePosition)).toArray();
     inputs.odometryTurnPositions =
         asyncOdometrySamples.stream()
             // should be after offset + gear ratio

--- a/src/main/java/frc/robot/subsystems/swerve/ModuleIOReal.java
+++ b/src/main/java/frc/robot/subsystems/swerve/ModuleIOReal.java
@@ -219,9 +219,8 @@ public class ModuleIOReal implements ModuleIO {
     inputs.odometryDrivePositionsMeters =
         asyncOdometrySamples.stream()
             .map(s -> s.values().get(drivePosition))
-            .map(d -> d == null ? new NullableDouble(null) : new NullableDouble(d))
+            .map(NullableDouble::new)
             .toArray(NullableDouble[]::new);
-    // mapToDouble(s -> s.values().get(drivePosition)).toArray();
     inputs.odometryTurnPositions =
         asyncOdometrySamples.stream()
             // should be after offset + gear ratio

--- a/src/main/java/frc/robot/subsystems/swerve/ModuleIOSim.java
+++ b/src/main/java/frc/robot/subsystems/swerve/ModuleIOSim.java
@@ -21,6 +21,7 @@ import edu.wpi.first.math.system.plant.DCMotor;
 import edu.wpi.first.wpilibj.Timer;
 import edu.wpi.first.wpilibj.simulation.DCMotorSim;
 import frc.robot.subsystems.swerve.PhoenixOdometryThread.Samples;
+import frc.robot.utils.NullableDouble;
 import frc.robot.utils.NullableRotation2d;
 import java.util.List;
 
@@ -75,7 +76,8 @@ public class ModuleIOSim implements ModuleIO {
     inputs.turnCurrentAmps = new double[] {Math.abs(turnSim.getCurrentDrawAmps())};
 
     inputs.odometryTimestamps = new double[] {Timer.getFPGATimestamp()};
-    inputs.odometryDrivePositionsMeters = new double[] {inputs.drivePositionMeters};
+    inputs.odometryDrivePositionsMeters =
+        new NullableDouble[] {new NullableDouble(inputs.drivePositionMeters)};
     inputs.odometryTurnPositions =
         new NullableRotation2d[] {new NullableRotation2d(inputs.turnPosition)};
   }

--- a/src/main/java/frc/robot/subsystems/swerve/SwerveSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/swerve/SwerveSubsystem.java
@@ -429,12 +429,14 @@ public class SwerveSubsystem extends SubsystemBase {
       SwerveModulePosition[] modulePositions = new SwerveModulePosition[4];
       SwerveModulePosition[] moduleDeltas =
           new SwerveModulePosition[4]; // change in positions since the last update
+      boolean isNull = false;
       for (int moduleIndex = 0; moduleIndex < 4; moduleIndex++) {
         modulePositions[moduleIndex] =
             modules[moduleIndex]
                 .getOdometryPositions()[deltaIndex]; // gets positions from the thread, NOT inputs
         // we can't do any odo updates if we are not getting module data
-        if (modulePositions[moduleIndex] == null) continue;
+        if (modulePositions[moduleIndex] == null) {isNull = true; continue;}
+        isNull = false;
         moduleDeltas[moduleIndex] =
             new SwerveModulePosition(
                 modulePositions[moduleIndex].distanceMeters
@@ -442,6 +444,7 @@ public class SwerveSubsystem extends SubsystemBase {
                 modulePositions[moduleIndex].angle);
         lastModulePositions[moduleIndex] = modulePositions[moduleIndex];
       }
+      if (isNull) continue;
 
       // The twist represents the motion of the robot since the last
       // sample in x, y, and theta based only on the modules, without

--- a/src/main/java/frc/robot/subsystems/swerve/SwerveSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/swerve/SwerveSubsystem.java
@@ -429,14 +429,14 @@ public class SwerveSubsystem extends SubsystemBase {
       SwerveModulePosition[] modulePositions = new SwerveModulePosition[4];
       SwerveModulePosition[] moduleDeltas =
           new SwerveModulePosition[4]; // change in positions since the last update
-      boolean isNull = false;
+      boolean hasNullModulePosition = false;
       for (int moduleIndex = 0; moduleIndex < 4; moduleIndex++) {
         modulePositions[moduleIndex] =
             modules[moduleIndex]
                 .getOdometryPositions()[deltaIndex]; // gets positions from the thread, NOT inputs
         // we can't do any odo updates if we are not getting module data
         if (modulePositions[moduleIndex] == null) {
-          isNull = true;
+          hasNullModulePosition = true;
 
           Logger.recordOutput("Odometry/Received Update From Module " + moduleIndex, false);
           break;
@@ -449,7 +449,7 @@ public class SwerveSubsystem extends SubsystemBase {
                 modulePositions[moduleIndex].angle);
         lastModulePositions[moduleIndex] = modulePositions[moduleIndex];
       }
-      if (isNull) {
+      if (hasNullModulePosition) {
         if (!gyroInputs.connected || gyroInputs.odometryYawPositions[deltaIndex].get() == null) {
           Logger.recordOutput("Odometry/Received Gyro Update", false);
           // no modules and no gyro so we're just sad :(

--- a/src/main/java/frc/robot/utils/NullableDouble.java
+++ b/src/main/java/frc/robot/utils/NullableDouble.java
@@ -12,7 +12,7 @@ public class NullableDouble implements StructSerializable {
   final Double value;
 
   public NullableDouble(Double value) {
-    isNull = value == null ? true : false;
+    isNull = value == null;
     this.value = value;
   }
 

--- a/src/main/java/frc/robot/utils/NullableDouble.java
+++ b/src/main/java/frc/robot/utils/NullableDouble.java
@@ -1,0 +1,24 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+package frc.robot.utils;
+
+import edu.wpi.first.util.struct.StructSerializable;
+
+/** Silly */
+public class NullableDouble implements StructSerializable {
+  final boolean isNull;
+  final Double value;
+
+  public NullableDouble(Double value) {
+    isNull = value == null ? true : false;
+    this.value = value;
+  }
+
+  public Double get() {
+    return isNull ? null : value;
+  }
+
+  public static final NullableDoubleStruct struct = new NullableDoubleStruct();
+}

--- a/src/main/java/frc/robot/utils/NullableDouble.java
+++ b/src/main/java/frc/robot/utils/NullableDouble.java
@@ -8,16 +8,14 @@ import edu.wpi.first.util.struct.StructSerializable;
 
 /** Silly */
 public class NullableDouble implements StructSerializable {
-  final boolean isNull;
   final Double value;
 
   public NullableDouble(Double value) {
-    isNull = value == null;
     this.value = value;
   }
 
   public Double get() {
-    return isNull ? null : value;
+    return value;
   }
 
   public static final NullableDoubleStruct struct = new NullableDoubleStruct();

--- a/src/main/java/frc/robot/utils/NullableDoubleStruct.java
+++ b/src/main/java/frc/robot/utils/NullableDoubleStruct.java
@@ -1,0 +1,53 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+package frc.robot.utils;
+
+import edu.wpi.first.util.struct.Struct;
+import java.nio.ByteBuffer;
+
+/** Silly */
+public class NullableDoubleStruct implements Struct<NullableDouble> {
+  @Override
+  public Class<NullableDouble> getTypeClass() {
+    return NullableDouble.class;
+  }
+
+  @Override
+  public String getTypeString() {
+    return "struct:NullableDouble";
+  }
+
+  @Override
+  public int getSize() {
+    return kSizeDouble + kSizeBool;
+  }
+
+  @Override
+  public String getSchema() {
+    return "boolean isNull; double value;";
+  }
+
+  @Override
+  public NullableDouble unpack(ByteBuffer bb) {
+    byte isNull = bb.get();
+    double value = bb.getDouble();
+    if (isNull == 0) {
+      return new NullableDouble(null);
+    } else {
+      return new NullableDouble(value);
+    }
+  }
+
+  @Override
+  public void pack(ByteBuffer bb, NullableDouble value) {
+    if (value.isNull) {
+      bb.put((byte) 0);
+      bb.putDouble(0);
+    } else {
+      bb.put((byte) 1);
+      bb.putDouble(value.get());
+    }
+  }
+}

--- a/src/main/java/frc/robot/utils/NullableDoubleStruct.java
+++ b/src/main/java/frc/robot/utils/NullableDoubleStruct.java
@@ -33,7 +33,7 @@ public class NullableDoubleStruct implements Struct<NullableDouble> {
   public NullableDouble unpack(ByteBuffer bb) {
     byte isNull = bb.get();
     double value = bb.getDouble();
-    if (isNull == -1) {
+    if (isNull == 1) {
       return new NullableDouble(null);
     } else {
       return new NullableDouble(value);
@@ -43,10 +43,10 @@ public class NullableDoubleStruct implements Struct<NullableDouble> {
   @Override
   public void pack(ByteBuffer bb, NullableDouble value) {
     if (value == null) {
-      bb.put((byte) -1);
+      bb.put((byte) 1);
       bb.putDouble(0);
     } else {
-      bb.put((byte) 1);
+      bb.put((byte) 0);
       bb.putDouble(value.get());
     }
   }

--- a/src/main/java/frc/robot/utils/NullableDoubleStruct.java
+++ b/src/main/java/frc/robot/utils/NullableDoubleStruct.java
@@ -33,7 +33,7 @@ public class NullableDoubleStruct implements Struct<NullableDouble> {
   public NullableDouble unpack(ByteBuffer bb) {
     byte isNull = bb.get();
     double value = bb.getDouble();
-    if (isNull == 0) {
+    if (isNull == -1) {
       return new NullableDouble(null);
     } else {
       return new NullableDouble(value);
@@ -42,8 +42,8 @@ public class NullableDoubleStruct implements Struct<NullableDouble> {
 
   @Override
   public void pack(ByteBuffer bb, NullableDouble value) {
-    if (value.isNull) {
-      bb.put((byte) 0);
+    if (value == null) {
+      bb.put((byte) -1);
       bb.putDouble(0);
     } else {
       bb.put((byte) 1);


### PR DESCRIPTION
added back nullable doubles, it should be able to survive module and gyro failures now and it will update the member variable pose with the gyro data if it has that but no modules. i would like to also update the estimator w/only gyro but i don't think that's super urgent rn or even possible