### PR TITLE
turned off ctre auto signal logging

### DIFF
--- a/src/main/java/frc/robot/Robot.java
+++ b/src/main/java/frc/robot/Robot.java
@@ -141,6 +141,7 @@ public class Robot extends LoggedRobot {
 
   @Override
   public void robotInit() {
+    SignalLogger.enableAutoLogging(false);
     RoboRioDataJNI.setBrownoutVoltage(6.0);
     // Metadata about the current code running on the robot
     Logger.recordMetadata("Codebase", "Comp2024");
@@ -1041,5 +1042,10 @@ public class Robot extends LoggedRobot {
   /** Modifies the given joystick axis value to make teleop driving smoother. */
   private static double teleopAxisAdjustment(double x) {
     return MathUtil.applyDeadband(Math.abs(Math.pow(x, 2)) * Math.signum(x), 0.02);
+  }
+
+  @Override
+  public void autonomousPeriodic() {
+    Tracer.traceFunc("Auto Periodic", super::autonomousPeriodic);
   }
 }


### PR DESCRIPTION
I'm not really sure what base branch i should be merging into but this should hopefully (at least mostly) resolve the awful loop overruns at the start of auto. It would be ideal to test this with an actual FMS because ctre seems to run it when an actual match starts (not sure if that is achievable before the season though)